### PR TITLE
Fix version in order to make it work in Ubuntu 14.04

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -31,7 +31,7 @@ const std::string CLIENT_NAME("Tokugawa");
 // git will put "#define GIT_ARCHIVE 1" on the next line inside archives. 
 #define GIT_ARCHIVE 1
 #ifdef GIT_ARCHIVE
-#    define GIT_COMMIT_ID "60026"
+#    define GIT_COMMIT_ID "60027"
 #endif
 
 #define BUILD_DESC_FROM_COMMIT(maj,min,rev,build,commit) \

--- a/src/version.h
+++ b/src/version.h
@@ -30,24 +30,24 @@ static const int DATABASE_VERSION = 70509;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60026;
+static const int PROTOCOL_VERSION = 60027;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 60026;
+static const int MIN_PEER_PROTO_VERSION = 60027;
 
 // minimum peer version accepted by DarkSendPool
-static const int MIN_POOL_PEER_PROTO_VERSION = 60026; 
+static const int MIN_POOL_PEER_PROTO_VERSION = 60027; 
 
-static const int MIN_INSTANTX_PROTO_VERSION = 60026;
+static const int MIN_INSTANTX_PROTO_VERSION = 60027;
 
 //! minimum peer version that can receive masternode payments
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 60026;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 60026;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 60027;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 60027;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Compiled software is not working in Ubuntu 14.04.

After compilation the masternode can not be changed to running mode.
(Status 2 and no rewards)

Debugging the log helped me to notice that a mismatch of the version was the issue.

Modified the version.h/version.cpp to protocol and version 60027.

Recompiled and tested, after this change the MNs work perfectly and receive the rewards normally.